### PR TITLE
Set UTF-8 locale on github action builds

### DIFF
--- a/.github/dockerfiles/Dockerfile.debian-base
+++ b/.github/dockerfiles/Dockerfile.debian-base
@@ -8,6 +8,8 @@ ARG BASE=debian
 
 ARG HOST_TRIP=x86_64-linux-gnu
 ENV HOST_TRIP=$HOST_TRIP
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssl-dev unixodbc-dev libgmp3-dev libwxbase3.0-dev libwxgtk3.0-dev libwxgtk-webview3.0-gtk3-dev libsctp-dev lksctp-tools"
 

--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -6,6 +6,8 @@ FROM ubuntu
 ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssl-dev unixodbc-dev libgmp3-dev libwxbase3.0-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev libsctp-dev lksctp-tools"
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 RUN apt-get update && \
         apt-get -y upgrade && \


### PR DESCRIPTION
Before, locale what set to "POSIX" which would cause java compiler
to assume pure ASCII source file and reject UTF-8 characters.

error: unmappable character (0xC3) for encoding US-ASCII